### PR TITLE
 Remove the call to isAlive() which is broken

### DIFF
--- a/lib/xspublic/xscommon/threading.cpp
+++ b/lib/xspublic/xscommon/threading.cpp
@@ -383,10 +383,18 @@ void StandardThread::stopThread(void) noexcept
 	//			return;
 	//	}
 	//#else
-	while (isAlive())
-		xsYield();
+	int rv = 0;
+	while (true) {
+		rv = pthread_tryjoin_np(m_thread, NULL);
+		if (rv == 0) {
+			break;
+		}
+		if (errno == EBUSY) {
+			xsYield();
+		}
+	}
 	//#endif
-	if (pthread_join(m_thread, NULL))
+	if (rv != 0)
 	{
 		switch (errno)
 		{

--- a/lib/xspublic/xscommon/threading.cpp
+++ b/lib/xspublic/xscommon/threading.cpp
@@ -391,6 +391,9 @@ void StandardThread::stopThread(void) noexcept
 		}
 		if (errno == EBUSY) {
 			xsYield();
+		} else {
+			// Some other error--maybe the thread is invalid?
+			break;
 		}
 	}
 	//#endif


### PR DESCRIPTION
The update of glibc from 2.31 to 2.35 in Ubuntu changed the semantics of pthread_kill. It used to return an error when a dead thread exited, and now it returns 0.

This new behavior is POSIX-compatible as the result of pthread_kill on a thread that died produces undefined behavior, so techincally 0 is valid result.

This isAlive() will return that a dead thread is alive in the newer glibc versions.

This patch removes the use of isAlive and instead uses tryjoin, which should behave correctly for dead threads.

[https://github.com/bluespace-ai/bluespace_ai_xsens_ros_mti_driver/pull/17](https://github.com/bluespace-ai/bluespace_ai_xsens_ros_mti_driver/pull/17)
